### PR TITLE
Add options for authentication based on SPAO and NTS to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ In an additional session:
 ~/scion-time/timeservice tool -verbose -local 0-0,0.0.0.0:0 -remote 0-0,127.0.0.1:10123
 ```
 
+## Querying an IP-based server with Network Time Security (NTS)
+
+In an additional session:
+
+```
+~/scion-time/timeservice tool -verbose -local 0-0,0.0.0.0:0 -remote 0-0,127.0.0.1:4460 -auth nts -ntske-insecure-skip-verify
+```
+
 ## Installing prerequisites for a SCION test environment
 
 Reference platform: Ubuntu 22.04 LTS, Go 1.19.7
@@ -59,10 +67,10 @@ On x86-64:
 
 ```
 sudo rm -rf /usr/local/go
-curl -LO https://golang.org/dl/go1.19.7.linux-amd64.tar.gz
-echo "7a75720c9b066ae1750f6bcc7052aba70fa3813f4223199ee2a2315fd3eb533d go1.19.7.linux-amd64.tar.gz" | sha256sum -c
-sudo tar -C /usr/local -xzf go1.19.7.linux-amd64.tar.gz
-rm go1.19.7.linux-amd64.tar.gz
+curl -LO https://golang.org/dl/go1.19.9.linux-amd64.tar.gz
+echo "e858173b489ec1ddbe2374894f52f53e748feed09dde61be5b4b4ba2d73ef34b go1.19.9.linux-amd64.tar.gz" | sha256sum -c
+sudo tar -C /usr/local -xzf go1.19.9.linux-amd64.tar.gz
+rm go1.19.9.linux-amd64.tar.gz
 echo >> .bash_profile
 echo 'export PATH=$PATH:/usr/local/go/bin' >> .bash_profile
 source ~/.bash_profile
@@ -73,10 +81,10 @@ On ARM64:
 
 ```
 sudo rm -rf /usr/local/go
-curl -LO https://golang.org/dl/go1.19.7.linux-arm64.tar.gz
-echo "071ea7bf386fdd08df524859b878d99fc359e491e7ad65c1c1cc55b67972c882 go1.19.7.linux-arm64.tar.gz" | sha256sum -c
-sudo tar -C /usr/local -xzf go1.19.7.linux-arm64.tar.gz
-rm go1.19.7.linux-arm64.tar.gz
+curl -LO https://golang.org/dl/go1.19.9.linux-arm64.tar.gz
+echo "b947e457be9d7b52a082c68e42b6939f9cc151f1ad5b3d8fd646ca3352f6f2f1 go1.19.9.linux-arm64.tar.gz" | sha256sum -c
+sudo tar -C /usr/local -xzf go1.19.9.linux-arm64.tar.gz
+rm go1.19.9.linux-arm64.tar.gz
 echo >> .bash_profile
 echo 'export PATH=$PATH:/usr/local/go/bin' >> .bash_profile
 source ~/.bash_profile
@@ -147,6 +155,36 @@ Or query server at `1-ff00:0:112,10.1.1.12:123` from `1-ff00:0:111,10.1.1.11`:
 
 ```
 sudo ip netns exec netns0 ~/scion-time/timeservice tool -verbose -daemon 10.1.1.11:30255 -local 1-ff00:0:111,10.1.1.11:0 -remote 1-ff00:0:112,10.1.1.12:123
+```
+
+### Querying a SCION-based server with SCION Packet Authenticator Option (SPAO)
+
+```
+sudo ip netns exec netns1 ~/scion-time/timeservice tool -verbose -daemon 10.1.1.12:30255 -local 1-ff00:0:112,10.1.1.12:0 -remote 1-ff00:0:111,10.1.1.11:123 -auth spao
+```
+
+### Querying a SCION-based server with Network Time Security (NTS)
+
+```
+sudo ip netns exec netns1 ~/scion-time/timeservice tool -verbose -daemon 10.1.1.12:30255 -local 1-ff00:0:112,10.1.1.12:0 -remote 1-ff00:0:111,10.1.1.11:4460 -auth nts -ntske-insecure-skip-verify
+```
+
+### Querying a SCION-based server with SPAO and NTS
+
+```
+sudo ip netns exec netns1 ~/scion-time/timeservice tool -verbose -daemon 10.1.1.12:30255 -local 1-ff00:0:112,10.1.1.12:0 -remote 1-ff00:0:111,10.1.1.11:4460 -auth spao,nts -ntske-insecure-skip-verify
+```
+
+### Querying a SCION-based server via IP
+
+```
+sudo ip netns exec netns1 ~/scion-time/timeservice tool -verbose -local 0-0,10.1.1.12:0 -remote 0-0,10.1.1.11:4460
+```
+
+### Querying a SCION-based server via IP with NTS
+
+```
+sudo ip netns exec netns1 ~/scion-time/timeservice tool -verbose -local 0-0,10.1.1.12:0 -remote 0-0,10.1.1.11:4460 -auth nts -ntske-insecure-skip-verify
 ```
 
 ## Synchronizing with a SCION-based server

--- a/net/ntske/ntske.go
+++ b/net/ntske/ntske.go
@@ -337,8 +337,8 @@ func NewListener(listener net.Listener) (*KeyExchange, error) {
 
 	ke.reader = bufio.NewReader(ke.Conn)
 
-	state := ke.Conn.ConnectionState()
-	fmt.Printf("negotiated proto: %v\n", state.NegotiatedProtocol)
+	// state := ke.Conn.ConnectionState()
+	// fmt.Printf("negotiated proto: %v\n", state.NegotiatedProtocol)
 	// if state.NegotiatedProtocol != alpn {
 	// 	return nil, fmt.Errorf("client not speaking ntske/1")
 	// }

--- a/timeservice.go
+++ b/timeservice.go
@@ -399,6 +399,10 @@ func createClocks(cfg svcConfig, localAddr *snet.UDPAddr) (
 	return
 }
 
+func copyIP(ip net.IP) net.IP {
+	return append(ip[:0:0], ip...)
+}
+
 func runServer(configFile string) {
 	ctx := context.Background()
 
@@ -423,7 +427,7 @@ func runServer(configFile string) {
 	tlsConfig := tlsConfig(cfg)
 	provider := ntske.NewProvider()
 
-	server.StartNTSKEServer(ctx, log, snet.CopyUDPAddr(localAddr.Host), tlsConfig, provider)
+	server.StartNTSKEServer(ctx, log, copyIP(localAddr.Host.IP), localAddr.Host.Port, tlsConfig, provider)
 	server.StartIPServer(ctx, log, snet.CopyUDPAddr(localAddr.Host), provider)
 	server.StartSCIONServer(ctx, log, daemonAddr, snet.CopyUDPAddr(localAddr.Host), provider)
 
@@ -454,7 +458,7 @@ func runRelay(configFile string) {
 	tlsConfig := tlsConfig(cfg)
 	provider := ntske.NewProvider()
 
-	server.StartNTSKEServer(ctx, log, snet.CopyUDPAddr(localAddr.Host), tlsConfig, provider)
+	server.StartNTSKEServer(ctx, log, copyIP(localAddr.Host.IP), localAddr.Host.Port, tlsConfig, provider)
 	server.StartIPServer(ctx, log, snet.CopyUDPAddr(localAddr.Host), provider)
 	server.StartSCIONServer(ctx, log, daemonAddr, snet.CopyUDPAddr(localAddr.Host), provider)
 


### PR DESCRIPTION
- Fix NTS-KE server code accordingly
- Update to Go version 1.19.9

**TODO**:
- [ ] Get rid off `-ntske-insecure-skip-verify` in README