### PR TITLE
Add QUIC support for SCION NTSKE

### DIFF
--- a/benchmark/client_scion.go
+++ b/benchmark/client_scion.go
@@ -20,20 +20,6 @@ import (
 	"example.com/scion-time/net/udp"
 )
 
-func newDaemonConnector(ctx context.Context, log *zap.Logger, daemonAddr string) daemon.Connector {
-	if daemonAddr == "" {
-		return nil
-	}
-	s := &daemon.Service{
-		Address: daemonAddr,
-	}
-	c, err := s.Connect(ctx)
-	if err != nil {
-		log.Fatal("failed to create demon connector", zap.Error(err))
-	}
-	return c
-}
-
 func RunSCIONBenchmark(daemonAddr string, localAddr, remoteAddr *snet.UDPAddr, authModes []string, ntskeServer string, log *zap.Logger) {
 	// const numClientGoroutine = 8
 	// const numRequestPerClient = 10000
@@ -50,7 +36,7 @@ func RunSCIONBenchmark(daemonAddr string, localAddr, remoteAddr *snet.UDPAddr, a
 			hg := hdrhistogram.New(1, 50000, 5)
 			ctx := context.Background()
 
-			dc := newDaemonConnector(ctx, log, daemonAddr)
+			dc := scion.NewDaemonConnector(ctx, log, daemonAddr)
 
 			var ps []snet.Path
 			if remoteAddr.IA.Equal(localAddr.IA) {

--- a/benchmark/client_scion.go
+++ b/benchmark/client_scion.go
@@ -95,6 +95,10 @@ func RunSCIONBenchmark(daemonAddr string, localAddr, remoteAddr *snet.UDPAddr, a
 				}
 				c.Auth.NTSKEFetcher.Port = ntskePort
 				c.Auth.NTSKEFetcher.Log = log
+				c.Auth.NTSKEFetcher.SCIONQuic.Enabled = true
+				c.Auth.NTSKEFetcher.SCIONQuic.DaemonAddr = daemonAddr
+				c.Auth.NTSKEFetcher.SCIONQuic.LocalAddr = laddr
+				c.Auth.NTSKEFetcher.SCIONQuic.RemoteAddr = raddr
 			}
 
 			defer wg.Done()

--- a/benchmark/client_scion.go
+++ b/benchmark/client_scion.go
@@ -95,10 +95,10 @@ func RunSCIONBenchmark(daemonAddr string, localAddr, remoteAddr *snet.UDPAddr, a
 				}
 				c.Auth.NTSKEFetcher.Port = ntskePort
 				c.Auth.NTSKEFetcher.Log = log
-				c.Auth.NTSKEFetcher.SCIONQuic.Enabled = true
-				c.Auth.NTSKEFetcher.SCIONQuic.DaemonAddr = daemonAddr
-				c.Auth.NTSKEFetcher.SCIONQuic.LocalAddr = laddr
-				c.Auth.NTSKEFetcher.SCIONQuic.RemoteAddr = raddr
+				c.Auth.NTSKEFetcher.QUIC.Enabled = true
+				c.Auth.NTSKEFetcher.QUIC.DaemonAddr = daemonAddr
+				c.Auth.NTSKEFetcher.QUIC.LocalAddr = laddr
+				c.Auth.NTSKEFetcher.QUIC.RemoteAddr = raddr
 			}
 
 			defer wg.Done()

--- a/benchmark/client_scion.go
+++ b/benchmark/client_scion.go
@@ -36,7 +36,7 @@ func RunSCIONBenchmark(daemonAddr string, localAddr, remoteAddr *snet.UDPAddr, a
 			hg := hdrhistogram.New(1, 50000, 5)
 			ctx := context.Background()
 
-			dc := scion.NewDaemonConnector(ctx, log, daemonAddr)
+			dc := scion.NewDaemonConnectorOption(ctx, log, daemonAddr)
 
 			var ps []snet.Path
 			if remoteAddr.IA.Equal(localAddr.IA) {

--- a/core/server/ntske.go
+++ b/core/server/ntske.go
@@ -1,10 +1,8 @@
 package server
 
 import (
-	"context"
-	"crypto/tls"
+	"errors"
 	"net"
-	"strconv"
 
 	"go.uber.org/zap"
 
@@ -13,23 +11,7 @@ import (
 
 const defaultNtskePort int = 4460
 
-func handleKeyExchange(log *zap.Logger, ke *ntske.KeyExchange, localPort int, provider *ntske.Provider) {
-	defer ke.Conn.Close()
-
-	err := ke.Read()
-	if err != nil {
-		log.Info("failed to read key exchange", zap.Error(err))
-		return
-	}
-
-	err = ke.ExportKeys()
-	if err != nil {
-		log.Info("failed to export keys", zap.Error(err))
-		return
-	}
-
-	localIP := ke.Conn.LocalAddr().(*net.TCPAddr).IP
-
+func createMessage(log *zap.Logger, localIP net.IP, localPort int, data *ntske.Data, provider *ntske.Provider) (ntske.ExchangeMsg, error) {
 	var msg ntske.ExchangeMsg
 	msg.AddRecord(ntske.NextProto{
 		NextProto: ntske.NTPv4,
@@ -46,8 +28,8 @@ func handleKeyExchange(log *zap.Logger, ke *ntske.KeyExchange, localPort int, pr
 
 	var plaintextCookie ntske.ServerCookie
 	plaintextCookie.Algo = ntske.AES_SIV_CMAC_256
-	plaintextCookie.C2S = ke.Meta.C2sKey
-	plaintextCookie.S2C = ke.Meta.S2cKey
+	plaintextCookie.C2S = data.C2sKey
+	plaintextCookie.S2C = data.S2cKey
 	key := provider.Current()
 	addedCookie := false
 	for i := 0; i < 8; i++ {
@@ -64,47 +46,10 @@ func handleKeyExchange(log *zap.Logger, ke *ntske.KeyExchange, localPort int, pr
 		addedCookie = true
 	}
 	if !addedCookie {
-		log.Info("failed to add at least one cookie")
-		return
+		return ntske.ExchangeMsg{}, errors.New("failed to add at least one cookie")
 	}
 
 	msg.AddRecord(ntske.End{})
 
-	buf, err := msg.Pack()
-	if err != nil {
-		log.Info("failed to build packet", zap.Error(err))
-		return
-	}
-
-	n, err := ke.Conn.Write(buf.Bytes())
-	if err != nil || n != buf.Len() {
-		log.Info("failed to write response", zap.Error(err))
-		return
-	}
-}
-
-func runNTSKEServer(log *zap.Logger, listener net.Listener, localPort int, provider *ntske.Provider) {
-	for {
-		ke, err := ntske.NewListener(listener)
-		if err != nil {
-			log.Info("failed to accept client", zap.Error(err))
-			continue
-		}
-		go handleKeyExchange(log, ke, localPort, provider)
-	}
-}
-
-func StartNTSKEServer(ctx context.Context, log *zap.Logger, localIP net.IP, localPort int, config *tls.Config, provider *ntske.Provider) {
-	ntskeAddr := net.JoinHostPort(localIP.String(), strconv.Itoa(defaultNtskePort))
-	log.Info("server listening via IP",
-		zap.Stringer("ip", localIP),
-		zap.Int("port", defaultNtskePort),
-	)
-
-	listener, err := tls.Listen("tcp", ntskeAddr, config)
-	if err != nil {
-		log.Error("failed to create TLS listener")
-	}
-
-	go runNTSKEServer(log, listener, localPort, provider)
+	return msg, nil
 }

--- a/core/server/ntske.go
+++ b/core/server/ntske.go
@@ -13,7 +13,7 @@ const defaultNTSKEPort = 4460
 
 var errNoCookie = errors.New("failed to add at least one cookie")
 
-func newNtskeMessage(log *zap.Logger, localIP net.IP, localPort int, data *ntske.Data, provider *ntske.Provider) (ntske.ExchangeMsg, error) {
+func newNTSKEMsg(log *zap.Logger, localIP net.IP, localPort int, data *ntske.Data, provider *ntske.Provider) (ntske.ExchangeMsg, error) {
 	var msg ntske.ExchangeMsg
 	msg.AddRecord(ntske.NextProto{
 		NextProto: ntske.NTPv4,

--- a/core/server/ntske.go
+++ b/core/server/ntske.go
@@ -11,7 +11,7 @@ import (
 
 const defaultNtskePort int = 4460
 
-func createMessage(log *zap.Logger, localIP net.IP, localPort int, data *ntske.Data, provider *ntske.Provider) (ntske.ExchangeMsg, error) {
+func newNtskeMessage(log *zap.Logger, localIP net.IP, localPort int, data *ntske.Data, provider *ntske.Provider) (ntske.ExchangeMsg, error) {
 	var msg ntske.ExchangeMsg
 	msg.AddRecord(ntske.NextProto{
 		NextProto: ntske.NTPv4,

--- a/core/server/ntske.go
+++ b/core/server/ntske.go
@@ -9,7 +9,9 @@ import (
 	"example.com/scion-time/net/ntske"
 )
 
-const defaultNtskePort int = 4460
+const defaultNtskePort = 4460
+
+var errNoCookie = errors.New("failed to add at least one cookie")
 
 func newNtskeMessage(log *zap.Logger, localIP net.IP, localPort int, data *ntske.Data, provider *ntske.Provider) (ntske.ExchangeMsg, error) {
 	var msg ntske.ExchangeMsg
@@ -46,7 +48,7 @@ func newNtskeMessage(log *zap.Logger, localIP net.IP, localPort int, data *ntske
 		addedCookie = true
 	}
 	if !addedCookie {
-		return ntske.ExchangeMsg{}, errors.New("failed to add at least one cookie")
+		return ntske.ExchangeMsg{}, errNoCookie
 	}
 
 	msg.AddRecord(ntske.End{})

--- a/core/server/ntske.go
+++ b/core/server/ntske.go
@@ -9,7 +9,7 @@ import (
 	"example.com/scion-time/net/ntske"
 )
 
-const defaultNtskePort = 4460
+const defaultNTSKEPort = 4460
 
 var errNoCookie = errors.New("failed to add at least one cookie")
 

--- a/core/server/ntske_ip.go
+++ b/core/server/ntske_ip.go
@@ -1,0 +1,102 @@
+package server
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"net"
+	"strconv"
+
+	"go.uber.org/zap"
+
+	"example.com/scion-time/net/ntske"
+)
+
+func sendErrorMessage(log *zap.Logger, conn *tls.Conn, code int) {
+	var msg ntske.ExchangeMsg
+	msg.AddRecord(ntske.Error{
+		Code: uint16(code),
+	})
+
+	buf, err := msg.Pack()
+	if err != nil {
+		log.Info("failed to build packet", zap.Error(err))
+		return
+	}
+
+	n, err := conn.Write(buf.Bytes())
+	if err != nil || n != buf.Len() {
+		log.Info("failed to write response", zap.Error(err))
+		return
+	}
+}
+
+func handleKeyExchange(log *zap.Logger, conn *tls.Conn, localPort int, provider *ntske.Provider) {
+	defer conn.Close()
+
+	var err error
+	var data ntske.Data
+	reader := bufio.NewReader(conn)
+	err = ntske.Read(log, reader, &data)
+	if err != nil {
+		log.Info("failed to read key exchange", zap.Error(err))
+		sendErrorMessage(log, conn, 1)
+		return
+	}
+
+	err = ntske.ExportKeys(conn.ConnectionState(), &data)
+	if err != nil {
+		log.Info("failed to export keys", zap.Error(err))
+		sendErrorMessage(log, conn, 2)
+		return
+	}
+
+	localIP := conn.LocalAddr().(*net.TCPAddr).IP
+
+	msg, err := createMessage(log, localIP, localPort, &data, provider)
+	if err != nil {
+		log.Info("failed to create packet", zap.Error(err))
+		sendErrorMessage(log, conn, 2)
+		return
+	}
+
+	buf, err := msg.Pack()
+	if err != nil {
+		log.Info("failed to build packet", zap.Error(err))
+		sendErrorMessage(log, conn, 2)
+		return
+	}
+
+	n, err := conn.Write(buf.Bytes())
+	if err != nil || n != buf.Len() {
+		log.Info("failed to write response", zap.Error(err))
+		return
+	}
+}
+
+func runNTSKEServer(log *zap.Logger, listener net.Listener, localPort int, provider *ntske.Provider) {
+	defer listener.Close()
+	for {
+		conn, err := ntske.NewTCPListener(listener)
+		if err != nil {
+			log.Info("failed to accept client", zap.Error(err))
+			continue
+		}
+		go handleKeyExchange(log, conn, localPort, provider)
+	}
+}
+
+func StartNTSKEServer(ctx context.Context, log *zap.Logger, localIP net.IP, localPort int, config *tls.Config, provider *ntske.Provider) {
+	ntskeAddr := net.JoinHostPort(localIP.String(), strconv.Itoa(defaultNtskePort))
+	log.Info("server listening via IP",
+		zap.Stringer("ip", localIP),
+		zap.Int("port", defaultNtskePort),
+	)
+
+	listener, err := tls.Listen("tcp", ntskeAddr, config)
+	if err != nil {
+		log.Error("failed to create TLS listener")
+	}
+
+	go runNTSKEServer(log, listener, localPort, provider)
+}

--- a/core/server/ntske_ip.go
+++ b/core/server/ntske_ip.go
@@ -40,14 +40,14 @@ func handleTCPKeyExchange(log *zap.Logger, conn *tls.Conn, localPort int, provid
 	err = ntske.Read(log, reader, &data)
 	if err != nil {
 		log.Info("failed to read key exchange", zap.Error(err))
-		sendNtskeTcpErrorMessage(log, conn, 1)
+		sendNtskeTcpErrorMessage(log, conn, ntske.BadRequestErrorCode)
 		return
 	}
 
 	err = ntske.ExportKeys(conn.ConnectionState(), &data)
 	if err != nil {
 		log.Info("failed to export keys", zap.Error(err))
-		sendNtskeTcpErrorMessage(log, conn, 2)
+		sendNtskeTcpErrorMessage(log, conn, ntske.InternalServerErrorCode)
 		return
 	}
 
@@ -56,14 +56,14 @@ func handleTCPKeyExchange(log *zap.Logger, conn *tls.Conn, localPort int, provid
 	msg, err := newNtskeMessage(log, localIP, localPort, &data, provider)
 	if err != nil {
 		log.Info("failed to create packet", zap.Error(err))
-		sendNtskeTcpErrorMessage(log, conn, 2)
+		sendNtskeTcpErrorMessage(log, conn, ntske.InternalServerErrorCode)
 		return
 	}
 
 	buf, err := msg.Pack()
 	if err != nil {
 		log.Info("failed to build packet", zap.Error(err))
-		sendNtskeTcpErrorMessage(log, conn, 2)
+		sendNtskeTcpErrorMessage(log, conn, ntske.InternalServerErrorCode)
 		return
 	}
 

--- a/core/server/ntske_ip.go
+++ b/core/server/ntske_ip.go
@@ -77,7 +77,7 @@ func handleTCPKeyExchange(log *zap.Logger, conn *tls.Conn, localPort int, provid
 func runNTSKEServer(log *zap.Logger, listener net.Listener, localPort int, provider *ntske.Provider) {
 	defer listener.Close()
 	for {
-		conn, err := ntske.NewTCPListener(listener)
+		conn, err := ntske.AcceptTLSConn(listener)
 		if err != nil {
 			log.Info("failed to accept client", zap.Error(err))
 			continue

--- a/core/server/ntske_scion.go
+++ b/core/server/ntske_scion.go
@@ -1,0 +1,97 @@
+package server
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"errors"
+	"net"
+
+	"github.com/quic-go/quic-go"
+	"go.uber.org/zap"
+
+	"example.com/scion-time/net/ntske"
+	"example.com/scion-time/net/scion"
+	"example.com/scion-time/net/udp"
+)
+
+func handleSCIONKeyExchange(log *zap.Logger, conn quic.Connection, localPort int, provider *ntske.Provider) error {
+	stream, err := conn.AcceptStream(context.Background())
+	if err != nil {
+		return err
+	}
+	defer quic.SendStream(stream).Close()
+
+	reader := bufio.NewReader(stream)
+	var data ntske.Data
+	err = ntske.Read(log, reader, &data)
+	if err != nil {
+		return errors.New("failed to read key exchange")
+	}
+
+	err = ntske.ExportKeys(conn.ConnectionState().TLS.ConnectionState, &data)
+	if err != nil {
+		return errors.New("failed to export keys")
+	}
+
+	localIP := conn.LocalAddr().(udp.UDPAddr).Host.IP
+
+	msg, err := createMessage(log, localIP, localPort, &data, provider)
+	if err != nil {
+		log.Info("failed to create packet", zap.Error(err))
+		return err
+	}
+
+	buf, err := msg.Pack()
+	if err != nil {
+		return errors.New("failed to build packet")
+	}
+
+	_, err = stream.Write(buf.Bytes())
+	if err != nil {
+		return err
+	}
+
+	quic.SendStream(stream).Close()
+
+	return nil
+}
+
+func runSCIONNTSKEServer(ctx context.Context, log *zap.Logger, listener quic.Listener, localPort int, provider *ntske.Provider) {
+	defer listener.Close()
+	for {
+		conn, err := ntske.NewQUICListener(context.Background(), listener)
+		if err != nil {
+			log.Info("failed to accept connection", zap.Error(err))
+			continue
+		}
+
+		go func() {
+			err := handleSCIONKeyExchange(log, conn, localPort, provider)
+			var errApplication *quic.ApplicationError
+			if err != nil && !(errors.As(err, &errApplication) && errApplication.ErrorCode == 0) {
+				log.Info("failed to handle connection",
+					zap.Stringer("remote", conn.RemoteAddr()),
+					zap.Error(err),
+				)
+			}
+		}()
+	}
+}
+
+func StartSCIONNTSKEServer(ctx context.Context, log *zap.Logger, localIP net.IP, localPort int, config *tls.Config, provider *ntske.Provider, localAddr udp.UDPAddr) {
+	//ntskeAddr := net.JoinHostPort(localIP.String(), strconv.Itoa(defaultNtskePort))
+	log.Info("server listening via SCION",
+		zap.Stringer("ip", localIP),
+		zap.Int("port", defaultNtskePort),
+	)
+
+	localAddr.Host.Port = defaultNtskePort
+
+	listener, err := scion.ListenQUIC(ctx, localAddr, config, nil /* quicCfg */)
+	if err != nil {
+		log.Fatal("failed to start listening", zap.Error(err))
+	}
+
+	go runSCIONNTSKEServer(ctx, log, listener, localPort, provider)
+}

--- a/core/server/ntske_scion.go
+++ b/core/server/ntske_scion.go
@@ -83,7 +83,7 @@ func handleQUICKeyExchange(log *zap.Logger, conn quic.Connection, localPort int,
 func runSCIONNTSKEServer(ctx context.Context, log *zap.Logger, listener quic.Listener, localPort int, provider *ntske.Provider) {
 	defer listener.Close()
 	for {
-		conn, err := ntske.NewQUICListener(context.Background(), listener)
+		conn, err := ntske.AcceptQUICConn(context.Background(), listener)
 		if err != nil {
 			log.Info("failed to accept connection", zap.Error(err))
 			continue

--- a/net/ntske/fetcher.go
+++ b/net/ntske/fetcher.go
@@ -33,7 +33,7 @@ type Fetcher struct {
 
 func (f *Fetcher) exchangeKeys() error {
 	if f.SCIONQuic.Enabled {
-		conn, _, err := ConnectQUIC(f.Log, f.SCIONQuic.LocalAddr, f.SCIONQuic.RemoteAddr, f.SCIONQuic.DaemonAddr, &f.TLSConfig)
+		conn, _, err := dialQUIC(f.Log, f.SCIONQuic.LocalAddr, f.SCIONQuic.RemoteAddr, f.SCIONQuic.DaemonAddr, &f.TLSConfig)
 		if err != nil {
 			return err
 		}
@@ -44,7 +44,7 @@ func (f *Fetcher) exchangeKeys() error {
 			}
 		}()
 
-		err = ExchangeQUIC(f.Log, conn, &f.data)
+		err = exchangeDataQUIC(f.Log, conn, &f.data)
 		if err != nil {
 			return err
 		}
@@ -59,12 +59,12 @@ func (f *Fetcher) exchangeKeys() error {
 		var err error
 		var conn *tls.Conn
 		serverAddr := net.JoinHostPort(f.TLSConfig.ServerName, f.Port)
-		conn, f.data, err = ConnectTCP(serverAddr, &f.TLSConfig)
+		conn, f.data, err = dialTLS(serverAddr, &f.TLSConfig)
 		if err != nil {
 			return err
 		}
 
-		err = ExchangeTCP(f.Log, conn, &f.data)
+		err = exchangeDataTLS(f.Log, conn, &f.data)
 		if err != nil {
 			return err
 		}

--- a/net/ntske/fetcher.go
+++ b/net/ntske/fetcher.go
@@ -13,6 +13,11 @@ import (
 	"example.com/scion-time/net/udp"
 )
 
+var (
+	errNoCookies   = errors.New("unexpected NTS-KE meta data: no cookies")
+	errUnknownAEAD = errors.New("unexpected NTS-KE meta data: unknown algorithm")
+)
+
 type Fetcher struct {
 	Log       *zap.Logger
 	TLSConfig tls.Config
@@ -65,10 +70,10 @@ func (f *Fetcher) exchangeKeys() error {
 		}
 
 		if len(f.data.Cookie) == 0 {
-			return errors.New("unexpected NTS-KE meta data: no cookies")
+			return errNoCookies
 		}
 		if f.data.Algo != AES_SIV_CMAC_256 {
-			return errors.New("unexpected NTS-KE meta data: unknown algorithm")
+			return errUnknownAEAD
 		}
 
 		err = ExportKeys(conn.ConnectionState(), &f.data)

--- a/net/ntske/ntske.go
+++ b/net/ntske/ntske.go
@@ -24,24 +24,12 @@ package ntske
 import (
 	"bufio"
 	"bytes"
-	"crypto/tls"
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"net"
-	"strconv"
-	"strings"
-	"time"
-)
 
-// KeyExchange is Network Time Security Key Exchange connection
-type KeyExchange struct {
-	hostport string
-	Conn     *tls.Conn
-	reader   *bufio.Reader
-	Meta     Data
-	Debug    bool
-}
+	"go.uber.org/zap"
+)
 
 // Data is negotiated data from the Key Exchange
 type Data struct {
@@ -126,14 +114,9 @@ func packheader(t uint16, c bool, buf *bytes.Buffer, bodylen int) error {
 
 }
 
-// Record is the interface all record types must implement. Header()
-// returns the record header. string() returns a printable
-// representation of the record type. pack() packs the record into
-// wire format.
+// Record is the interface all record types must implement.
+// pack() packs the record into wire format.
 type Record interface {
-	Header() RecordHdr
-
-	string() string
 	pack(*bytes.Buffer) error
 }
 
@@ -141,14 +124,6 @@ type Record interface {
 // to the peer.
 type ExchangeMsg struct {
 	Record []Record
-}
-
-// String prints a description of all recortds in the Key Exchange
-// message.
-func (m ExchangeMsg) String() {
-	for _, r := range m.Record {
-		fmt.Printf(r.string())
-	}
 }
 
 // Pack allocates a buffer and packs all records into wire format in
@@ -179,10 +154,6 @@ const NTPv4 uint16 = 0
 type NextProto struct {
 	RecordHdr
 	NextProto uint16
-}
-
-func (n NextProto) string() string {
-	return fmt.Sprintf("--NextProto: %v\n", n.NextProto)
 }
 
 func (n NextProto) pack(buf *bytes.Buffer) error {
@@ -218,10 +189,6 @@ func (e End) pack(buf *bytes.Buffer) error {
 	return packheader(RecEom, true, buf, 0)
 }
 
-func (e End) string() string {
-	return fmt.Sprintf("--EOM\n")
-}
-
 // Server is the NTP Server record, telling the client to use a
 // certain server for the next protocol query. Critical bit is
 // optional. Set Critical to true if you want it set.
@@ -233,10 +200,6 @@ type Server struct {
 
 func (s Server) pack(buf *bytes.Buffer) error {
 	return packsimple(RecServer, s.Critical, s.Addr, buf)
-}
-
-func (s Server) string() string {
-	return fmt.Sprintf("--Server: %v\n", string(s.Addr))
 }
 
 // Port is the NTP Port record, telling the client to use this port
@@ -252,10 +215,6 @@ func (p Port) pack(buf *bytes.Buffer) error {
 	return packsimple(RecPort, p.Critical, p.Port, buf)
 }
 
-func (p Port) string() string {
-	return fmt.Sprintf("--Port: %v\n", p.Port)
-}
-
 // Cookie is an NTS cookie to be used when querying time over NTS.
 type Cookie struct {
 	RecordHdr
@@ -264,10 +223,6 @@ type Cookie struct {
 
 func (c Cookie) pack(buf *bytes.Buffer) error {
 	return packsimple(RecCookie, false, c.Cookie, buf)
-}
-
-func (c Cookie) string() string {
-	return fmt.Sprintf("--Cookie: %x\n", c.Cookie)
 }
 
 // Warning is the record type to send warnings to the other end. Put
@@ -279,10 +234,6 @@ type Warning struct {
 
 func (w Warning) pack(buf *bytes.Buffer) error {
 	return packsimple(RecWarning, true, w.Code, buf)
-}
-
-func (w Warning) string() string {
-	return fmt.Sprintf("--Warning: %x\n", w.Code)
 }
 
 // Error is the record type to send errors to the other end. Put
@@ -297,10 +248,6 @@ func (e Error) pack(buf *bytes.Buffer) error {
 
 }
 
-func (e Error) string() string {
-	return fmt.Sprintf("--Error: %x\n", e.Code)
-}
-
 // Algorithm is the record type for a list of AEAD algorithm we can use.
 type Algorithm struct {
 	RecordHdr
@@ -311,174 +258,12 @@ func (a Algorithm) pack(buf *bytes.Buffer) error {
 	return packsimple(RecAead, true, a.Algo, buf)
 }
 
-func (a Algorithm) string() string {
-	var str string = "--AEAD: \n"
-
-	for i, alg := range a.Algo {
-		algstr := fmt.Sprintf("  #%v: %v\n", i, alg)
-		str = str + algstr
-	}
-
-	return str
-}
-
-func NewListener(listener net.Listener) (*KeyExchange, error) {
-	ke := new(KeyExchange)
-	conn, err := listener.Accept()
-	if err != nil {
-		return nil, fmt.Errorf("Couldn't answer`")
-	}
-
-	var ok bool
-	ke.Conn, ok = conn.(*tls.Conn)
-	if !ok {
-		return nil, fmt.Errorf("could not convert to tls connection")
-	}
-
-	ke.reader = bufio.NewReader(ke.Conn)
-
-	// state := ke.Conn.ConnectionState()
-	// fmt.Printf("negotiated proto: %v\n", state.NegotiatedProtocol)
-	// if state.NegotiatedProtocol != alpn {
-	// 	return nil, fmt.Errorf("client not speaking ntske/1")
-	// }
-
-	return ke, nil
-}
-
-// Connect connects to host:port and establishes an NTS-KE connection.
-// If :port is left out, protocol default port is used.
-// No further action is done.
-func Connect(hostport string, config *tls.Config, debug bool) (*KeyExchange, error) {
-	config.NextProtos = []string{alpn}
-
-	ke := new(KeyExchange)
-	ke.Debug = debug
-	ke.hostport = hostport
-
-	_, _, err := net.SplitHostPort(ke.hostport)
-	if err != nil {
-		if !strings.Contains(err.Error(), "missing port in address") {
-			return nil, err
-		}
-		ke.hostport = net.JoinHostPort(ke.hostport, strconv.Itoa(DEFAULT_NTSKE_PORT))
-	}
-
-	if ke.Debug {
-		fmt.Printf("Connecting to KE server %v\n", ke.hostport)
-	}
-	ke.Conn, err = tls.DialWithDialer(&net.Dialer{
-		Timeout: time.Second * 5,
-	}, "tcp", ke.hostport, config)
-	if err != nil {
-		return nil, err
-	}
-
-	// Set default NTP server to the IP resolved and connected to for NTS-KE.
-	// Handles multiple A records & possible lack of NTPv4 Server Negotiation.
-	ke.Meta.Server, _, err = net.SplitHostPort(ke.Conn.RemoteAddr().String())
-	if err != nil {
-		return nil, fmt.Errorf("unexpected remoteaddr issue: %s", err)
-	}
-	ke.Meta.Port = DEFAULT_NTP_PORT
-
-	if ke.Debug {
-		fmt.Printf("Using resolved KE server as NTP default: %v\n",
-			net.JoinHostPort(ke.Meta.Server, strconv.Itoa(int(ke.Meta.Port))))
-	}
-	ke.reader = bufio.NewReader(ke.Conn)
-
-	state := ke.Conn.ConnectionState()
-	if state.NegotiatedProtocol != alpn {
-		return nil, fmt.Errorf("server not speaking ntske/1")
-	}
-
-	return ke, nil
-}
-
-// Exchange initiates a client exchange using sane defaults on a
-// connection already established with Connect(). After a succesful
-// run negotiated data is in ke.Meta.
-func (ke *KeyExchange) Exchange() error {
-	var msg ExchangeMsg
-	var nextproto NextProto
-
-	nextproto.NextProto = NTPv4
-	msg.AddRecord(nextproto)
-
-	var algo Algorithm
-	algo.Algo = []uint16{AES_SIV_CMAC_256}
-	msg.AddRecord(algo)
-
-	var end End
-	msg.AddRecord(end)
-
-	buf, err := msg.Pack()
-	if err != nil {
-		return err
-	}
-
-	_, err = ke.Conn.Write(buf.Bytes())
-	if err != nil {
-		return err
-	}
-
-	// Wait for response
-	err = ke.Read()
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// ExportKeys exports two extra sessions keys from the already
-// established NTS-KE connection for use with NTS.
-func (ke *KeyExchange) ExportKeys() error {
-	// 4.3. in the the rfc https://tools.ietf.org/html/rfc8915#section-4.3
-	label := "EXPORTER-network-time-security"
-	// The per-association context value SHALL consist of the following
-	// five octets:
-	//
-	// The first two octets SHALL be zero (the Protocol ID for NTPv4).
-	//
-	// The next two octets SHALL be the Numeric Identifier of the
-	// negotiated AEAD Algorithm in network byte order. Typically
-	// 0x0f for AES-SIV-CMAC-256.
-	//
-	// The final octet SHALL be 0x00 for the C2S key and 0x01 for the
-	// S2C key.
-	s2c_context := make([]byte, 4)
-	binary.BigEndian.PutUint16(s2c_context[2:], ke.Meta.Algo)
-	s2c_context = append(s2c_context, 0x01)
-
-	c2s_context := make([]byte, 4)
-	binary.BigEndian.PutUint16(c2s_context[2:], ke.Meta.Algo)
-	c2s_context = append(c2s_context, 0x00)
-
-	var keylength = 32
-	var err error
-
-	state := ke.Conn.ConnectionState()
-	if ke.Meta.C2sKey, err = state.ExportKeyingMaterial(label, c2s_context, keylength); err != nil {
-		return err
-	}
-	if ke.Meta.S2cKey, err = state.ExportKeyingMaterial(label, s2c_context, keylength); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// Read reads incoming NTS-KE messages until an End of Message record
-// is received or an error occur. It fills out the ke.Meta structure
-// with negotiated data.
-func (ke *KeyExchange) Read() error {
+func Read(log *zap.Logger, reader *bufio.Reader, data *Data) error {
 	var msg RecordHdr
 	var critical bool
 
 	for {
-		err := binary.Read(ke.reader, binary.BigEndian, &msg)
+		err := binary.Read(reader, binary.BigEndian, &msg)
 		if err != nil {
 			return err
 		}
@@ -497,67 +282,51 @@ func (ke *KeyExchange) Read() error {
 		// Get rid of Critical bit.
 		msg.Type &^= (1 << 15)
 
-		if ke.Debug {
-			fmt.Printf("Record type %v\n", msg.Type)
-			if critical {
-				fmt.Printf("Critical set\n")
-			}
-		}
-
 		switch msg.Type {
 		case RecEom:
-			// Check that we have complete data.
-			// if len(ke.Meta.Cookie) == 0 || ke.Meta.Algo == 0 {
-			// 	return errors.New("incomplete data")
-			// }
-
 			return nil
 
 		case RecNextproto:
 			var nextProto uint16
-			err := binary.Read(ke.reader, binary.BigEndian, &nextProto)
+			err := binary.Read(reader, binary.BigEndian, &nextProto)
 			if err != nil {
 				return errors.New("buffer overrun")
 			}
 
 		case RecAead:
 			var aead uint16
-			err := binary.Read(ke.reader, binary.BigEndian, &aead)
+			err := binary.Read(reader, binary.BigEndian, &aead)
 			if err != nil {
 				return errors.New("buffer overrun")
 			}
 
-			ke.Meta.Algo = aead
+			data.Algo = aead
 
 		case RecCookie:
 			cookie := make([]byte, msg.BodyLen)
-			_, err := ke.reader.Read(cookie)
+			_, err := reader.Read(cookie)
 			if err != nil {
 				return errors.New("buffer overrun")
 			}
 
-			ke.Meta.Cookie = append(ke.Meta.Cookie, cookie)
+			data.Cookie = append(data.Cookie, cookie)
 
 		case RecServer:
 			address := make([]byte, msg.BodyLen)
 
-			err := binary.Read(ke.reader, binary.BigEndian, &address)
+			err := binary.Read(reader, binary.BigEndian, &address)
 			if err != nil {
 				return errors.New("buffer overrun")
 			}
-			ke.Meta.Server = string(address)
-			if ke.Debug {
-				fmt.Printf("(got negotiated NTP server: %v)\n", ke.Meta.Server)
-			}
+			data.Server = string(address)
+			// log.Debug("NTSKE", zap.String("negotiated NTP server", data.Server))
 
 		case RecPort:
-			err := binary.Read(ke.reader, binary.BigEndian, &ke.Meta.Port)
+			err := binary.Read(reader, binary.BigEndian, &data.Port)
 			if err != nil {
 				return errors.New("buffer overrun")
 			}
-			if ke.Debug {
-				fmt.Printf("(got negotiated NTP port: %v)\n", ke.Meta.Port)
-			}
+			// log.Debug("NTSKE", zap.Uint16("negotiated port", data.Port))
 
 		default:
 			if critical {
@@ -566,7 +335,7 @@ func (ke *KeyExchange) Read() error {
 
 			// Swallow unknown record.
 			unknownMsg := make([]byte, msg.BodyLen)
-			err := binary.Read(ke.reader, binary.BigEndian, &unknownMsg)
+			err := binary.Read(reader, binary.BigEndian, &unknownMsg)
 			if err != nil {
 				return errors.New("buffer overrun")
 			}

--- a/net/ntske/ntske.go
+++ b/net/ntske/ntske.go
@@ -61,18 +61,18 @@ const (
 )
 
 const (
-	UnrecognizedCriticalErrorCode = 0
-	BadRequestErrorCode           = 1
-	InternalServerErrorCode       = 2
+	ErrorCodeUnrecognizedCritical = 0
+	ErrorCodeBadRequest           = 1
+	ErrorCodeInternalServer       = 2
 )
 
 const alpn = "ntske/1"
 
 var (
-	errServerNoNTSKE            = errors.New("server not speaking ntske/1")
+	errServerNoNTSKE            = errors.New("server does not support ntske/1")
 	errReadInternalServer       = errors.New("ntske received internal server error message")
 	errReadBadRequest           = errors.New("ntske received bad request error message")
-	errReadUnrecognisedCritical = errors.New("ntske received unrecognised critical error message")
+	errReadUnrecognisedCritical = errors.New("ntske received unrecognized critical error message")
 	errReadUnknown              = errors.New("ntske received unknown error message")
 )
 
@@ -295,7 +295,7 @@ func ExportKeys(cs tls.ConnectionState, data *Data) error {
 	return nil
 }
 
-func Read(log *zap.Logger, reader *bufio.Reader, data *Data) error {
+func ReadData(log *zap.Logger, reader *bufio.Reader, data *Data) error {
 	var msg RecordHdr
 	var critical bool
 
@@ -367,11 +367,11 @@ func Read(log *zap.Logger, reader *bufio.Reader, data *Data) error {
 			if err != nil {
 				return err
 			}
-			if code == 0 {
+			if code == ErrorCodeUnrecognizedCritical {
 				return errReadUnrecognisedCritical
-			} else if code == 1 {
+			} else if code == ErrorCodeBadRequest {
 				return errReadBadRequest
-			} else if code == 2 {
+			} else if code == ErrorCodeInternalServer {
 				return errReadInternalServer
 			}
 			return errReadUnknown

--- a/net/ntske/ntske_ip.go
+++ b/net/ntske/ntske_ip.go
@@ -1,0 +1,122 @@
+package ntske
+
+import (
+	"bufio"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+func NewTCPListener(listener net.Listener) (*tls.Conn, error) {
+	conn, err := listener.Accept()
+	if err != nil {
+		return nil, fmt.Errorf("Couldn't answer`")
+	}
+
+	tlsConn, ok := conn.(*tls.Conn)
+	if !ok {
+		return nil, fmt.Errorf("could not convert to tls connection")
+	}
+
+	//state := tlsConn.ConnectionState()
+	//if state.NegotiatedProtocol != alpn {
+	//	fmt.Println(state.NegotiatedProtocol)
+	//	return nil, fmt.Errorf("client not speaking ntske/1")
+	//}
+
+	return tlsConn, nil
+}
+
+func ConnectTCP(hostport string, config *tls.Config) (*tls.Conn, Data, error) {
+	config.NextProtos = []string{alpn}
+
+	_, _, err := net.SplitHostPort(hostport)
+	if err != nil {
+		if !strings.Contains(err.Error(), "missing port in address") {
+			return nil, Data{}, err
+		}
+		hostport = net.JoinHostPort(hostport, strconv.Itoa(DEFAULT_NTSKE_PORT))
+	}
+
+	conn, err := tls.DialWithDialer(&net.Dialer{
+		Timeout: time.Second * 5,
+	}, "tcp", hostport, config)
+	if err != nil {
+		return nil, Data{}, err
+	}
+
+	var data Data
+	data.Server, _, err = net.SplitHostPort(conn.RemoteAddr().String())
+	if err != nil {
+		return nil, Data{}, fmt.Errorf("unexpected remoteaddr issue: %s", err)
+	}
+	data.Port = DEFAULT_NTP_PORT
+
+	state := conn.ConnectionState()
+	if state.NegotiatedProtocol != alpn {
+		return nil, Data{}, fmt.Errorf("server not speaking ntske/1")
+	}
+
+	return conn, data, nil
+}
+
+func ExchangeTCP(log *zap.Logger, conn *tls.Conn, data *Data) error {
+	reader := bufio.NewReader(conn)
+
+	var msg ExchangeMsg
+	var nextproto NextProto
+
+	nextproto.NextProto = NTPv4
+	msg.AddRecord(nextproto)
+
+	var algo Algorithm
+	algo.Algo = []uint16{AES_SIV_CMAC_256}
+	msg.AddRecord(algo)
+
+	var end End
+	msg.AddRecord(end)
+
+	buf, err := msg.Pack()
+	if err != nil {
+		return err
+	}
+
+	_, err = conn.Write(buf.Bytes())
+	if err != nil {
+		return err
+	}
+
+	err = Read(log, reader, data)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ExportKeys exports two extra sessions keys from the already
+// established NTS-KE connection for use with NTS.
+func ExportKeys(cs tls.ConnectionState, data *Data) error {
+	label := "EXPORTER-network-time-security"
+	s2cContext := []byte{0x00, 0x00, 0x00, 0x0f, 0x01}
+	c2sContext := []byte{0x00, 0x00, 0x00, 0x0f, 0x00}
+	len := 32
+
+	var err error
+	data.S2cKey, err = cs.ExportKeyingMaterial(label, s2cContext, len)
+	if err != nil {
+		return err
+	}
+
+	data.C2sKey, err = cs.ExportKeyingMaterial(label, c2sContext, len)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/net/ntske/ntske_ip.go
+++ b/net/ntske/ntske_ip.go
@@ -98,25 +98,3 @@ func ExchangeTCP(log *zap.Logger, conn *tls.Conn, data *Data) error {
 
 	return nil
 }
-
-// ExportKeys exports two extra sessions keys from the already
-// established NTS-KE connection for use with NTS.
-func ExportKeys(cs tls.ConnectionState, data *Data) error {
-	label := "EXPORTER-network-time-security"
-	s2cContext := []byte{0x00, 0x00, 0x00, 0x0f, 0x01}
-	c2sContext := []byte{0x00, 0x00, 0x00, 0x0f, 0x00}
-	len := 32
-
-	var err error
-	data.S2cKey, err = cs.ExportKeyingMaterial(label, s2cContext, len)
-	if err != nil {
-		return err
-	}
-
-	data.C2sKey, err = cs.ExportKeyingMaterial(label, c2sContext, len)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}

--- a/net/ntske/ntske_ip.go
+++ b/net/ntske/ntske_ip.go
@@ -86,7 +86,7 @@ func exchangeDataTLS(log *zap.Logger, conn *tls.Conn, data *Data) error {
 	}
 
 	reader := bufio.NewReader(conn)
-	err = Read(log, reader, data)
+	err = ReadData(log, reader, data)
 	if err != nil {
 		return err
 	}

--- a/net/ntske/ntske_scion.go
+++ b/net/ntske/ntske_scion.go
@@ -98,7 +98,7 @@ func exchangeDataQUIC(log *zap.Logger, conn *scion.QUICConnection, data *Data) e
 	quic.SendStream(stream).Close()
 
 	reader := bufio.NewReader(stream)
-	err = Read(log, reader, data)
+	err = ReadData(log, reader, data)
 	if err != nil {
 		return err
 	}

--- a/net/ntske/ntske_scion.go
+++ b/net/ntske/ntske_scion.go
@@ -40,7 +40,6 @@ func dialQUIC(log *zap.Logger, localAddr, remoteAddr udp.UDPAddr, daemonAddr str
 	conn, err := scion.DialQUIC(ctx, localAddr, remoteAddr, sp,
 		"" /* host*/, config, nil /* quicCfg */)
 	if err != nil {
-		_ = conn.Close()
 		return nil, Data{}, err
 	}
 

--- a/net/ntske/ntske_scion.go
+++ b/net/ntske/ntske_scion.go
@@ -55,11 +55,6 @@ func ConnectQUIC(log *zap.Logger, localAddr, remoteAddr udp.UDPAddr, daemonAddr 
 		return nil, Data{}, err
 	}
 
-	//state := conn.ConnectionState().TLS.ConnectionState
-	//if state.NegotiatedProtocol != alpn {
-	//	return nil, Data{}, fmt.Errorf("server not speaking ntske/1")
-	//}
-
 	return conn, Data{}, nil
 }
 

--- a/net/ntske/ntske_scion.go
+++ b/net/ntske/ntske_scion.go
@@ -35,7 +35,6 @@ func NewQUICListener(ctx context.Context, listener quic.Listener) (quic.Connecti
 
 func ConnectQUIC(log *zap.Logger, localAddr, remoteAddr udp.UDPAddr, daemonAddr string, config *tls.Config) (*scion.QUICConnection, Data, error) {
 	config.NextProtos = []string{alpn}
-
 	ctx := context.Background()
 
 	dc := newDaemonConnector(log, ctx, daemonAddr)

--- a/net/ntske/ntske_scion.go
+++ b/net/ntske/ntske_scion.go
@@ -1,0 +1,105 @@
+package ntske
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+
+	"github.com/quic-go/quic-go"
+	"go.uber.org/zap"
+
+	"github.com/scionproto/scion/pkg/daemon"
+
+	"example.com/scion-time/net/scion"
+	"example.com/scion-time/net/udp"
+)
+
+func newDaemonConnector(log *zap.Logger, ctx context.Context, daemonAddr string) daemon.Connector {
+	s := &daemon.Service{
+		Address: daemonAddr,
+	}
+	c, err := s.Connect(ctx)
+	if err != nil {
+		log.Fatal("failed to create demon connector", zap.Error(err))
+	}
+	return c
+}
+
+func NewQUICListener(ctx context.Context, listener quic.Listener) (quic.Connection, error) {
+	conn, err := listener.Accept(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return conn, nil
+}
+
+func ConnectQUIC(log *zap.Logger, localAddr, remoteAddr udp.UDPAddr, daemonAddr string, config *tls.Config) (*scion.QUICConnection, Data, error) {
+	config.NextProtos = []string{alpn}
+
+	ctx := context.Background()
+
+	dc := newDaemonConnector(log, ctx, daemonAddr)
+	ps, err := dc.Paths(ctx, remoteAddr.IA, localAddr.IA, daemon.PathReqFlags{Refresh: true})
+	if err != nil {
+		log.Fatal("failed to lookup paths", zap.Stringer("to", remoteAddr.IA), zap.Error(err))
+	}
+	if len(ps) == 0 {
+		log.Fatal("no paths available", zap.Stringer("to", remoteAddr.IA))
+	}
+	log.Debug("available paths", zap.Stringer("to", remoteAddr.IA), zap.Array("via", scion.PathArrayMarshaler{Paths: ps}))
+	sp := ps[0]
+	log.Debug("selected path", zap.Stringer("to", remoteAddr.IA), zap.Object("via", scion.PathMarshaler{Path: sp}))
+
+	conn, err := scion.DialQUIC(ctx, localAddr, remoteAddr, sp,
+		"" /* host*/, config, nil /* quicCfg */)
+	if err != nil {
+		return nil, Data{}, err
+	}
+
+	//state := conn.ConnectionState().TLS.ConnectionState
+	//if state.NegotiatedProtocol != alpn {
+	//	return nil, Data{}, fmt.Errorf("server not speaking ntske/1")
+	//}
+
+	return conn, Data{}, nil
+}
+
+func ExchangeQUIC(log *zap.Logger, conn *scion.QUICConnection, data *Data) error {
+	stream, err := conn.OpenStream()
+	if err != nil {
+		return err
+	}
+	defer quic.SendStream(stream).Close()
+
+	var msg ExchangeMsg
+	var nextproto NextProto
+
+	nextproto.NextProto = NTPv4
+	msg.AddRecord(nextproto)
+
+	var algo Algorithm
+	algo.Algo = []uint16{AES_SIV_CMAC_256}
+	msg.AddRecord(algo)
+
+	var end End
+	msg.AddRecord(end)
+
+	buf, err := msg.Pack()
+	if err != nil {
+		return err
+	}
+
+	_, err = stream.Write(buf.Bytes())
+	if err != nil {
+		return err
+	}
+	quic.SendStream(stream).Close()
+	reader := bufio.NewReader(stream)
+
+	// Wait for response
+	err = Read(log, reader, data)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/net/scion/daemon.go
+++ b/net/scion/daemon.go
@@ -1,0 +1,27 @@
+package scion
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+
+	"github.com/scionproto/scion/pkg/daemon"
+)
+
+func NewDaemonConnector(ctx context.Context, log *zap.Logger, daemonAddr string) daemon.Connector {
+	s := &daemon.Service{
+		Address: daemonAddr,
+	}
+	c, err := s.Connect(ctx)
+	if err != nil {
+		log.Fatal("failed to create demon connector", zap.Error(err))
+	}
+	return c
+}
+
+func NewDaemonConnectorOption(ctx context.Context, log *zap.Logger, daemonAddr string) daemon.Connector {
+	if daemonAddr == "" {
+		return nil
+	}
+	return NewDaemonConnector(ctx, log, daemonAddr)
+}

--- a/net/scion/pather.go
+++ b/net/scion/pather.go
@@ -62,20 +62,9 @@ func update(ctx context.Context, p *Pather, dc daemon.Connector, dstIAs []addr.I
 	p.mu.Unlock()
 }
 
-func newDaemonConnector(ctx context.Context, log *zap.Logger, daemonAddr string) daemon.Connector {
-	s := &daemon.Service{
-		Address: daemonAddr,
-	}
-	c, err := s.Connect(ctx)
-	if err != nil {
-		log.Fatal("failed to create demon connector", zap.Error(err))
-	}
-	return c
-}
-
 func StartPather(ctx context.Context, log *zap.Logger, daemonAddr string, dstIAs []addr.IA) *Pather {
 	p := &Pather{log: log}
-	dc := newDaemonConnector(ctx, log, daemonAddr)
+	dc := NewDaemonConnector(ctx, log, daemonAddr)
 	update(ctx, p, dc, dstIAs)
 	go func(ctx context.Context, p *Pather, dc daemon.Connector, dstIAs []addr.IA) {
 		ticker := time.NewTicker(pathRefreshPeriod)

--- a/testnet/benchmark/nts_benchmark.toml
+++ b/testnet/benchmark/nts_benchmark.toml
@@ -1,0 +1,5 @@
+local_address = "1-ff00:0:111,0.0.0.0:0"
+remote_address = "1-ff00:0:111,10.1.1.11:4460"
+
+auth_modes = ["nts", "spao"]
+ntske_insecure_skip_verify = true

--- a/testnet/benchmark/nts_benchmark.toml
+++ b/testnet/benchmark/nts_benchmark.toml
@@ -1,5 +1,0 @@
-local_address = "1-ff00:0:111,0.0.0.0:0"
-remote_address = "1-ff00:0:111,10.1.1.11:4460"
-
-auth_modes = ["nts", "spao"]
-ntske_insecure_skip_verify = true

--- a/timeservice.go
+++ b/timeservice.go
@@ -213,10 +213,10 @@ func configureSCIONClientNTS(c *client.SCIONClient, ntskeServer string, ntskeIns
 	}
 	c.Auth.NTSKEFetcher.Port = ntskePort
 	c.Auth.NTSKEFetcher.Log = log
-	c.Auth.NTSKEFetcher.SCIONQuic.Enabled = true
-	c.Auth.NTSKEFetcher.SCIONQuic.DaemonAddr = daemonAddr
-	c.Auth.NTSKEFetcher.SCIONQuic.LocalAddr = localAddr
-	c.Auth.NTSKEFetcher.SCIONQuic.RemoteAddr = remoteAddr
+	c.Auth.NTSKEFetcher.QUIC.Enabled = true
+	c.Auth.NTSKEFetcher.QUIC.DaemonAddr = daemonAddr
+	c.Auth.NTSKEFetcher.QUIC.LocalAddr = localAddr
+	c.Auth.NTSKEFetcher.QUIC.RemoteAddr = remoteAddr
 }
 
 func newNTPReferenceClockSCION(daemonAddr string, localAddr, remoteAddr udp.UDPAddr,

--- a/timeservice.go
+++ b/timeservice.go
@@ -436,8 +436,8 @@ func runServer(configFile string) {
 	tlsConfig := tlsConfig(cfg)
 	provider := ntske.NewProvider()
 
-	server.StartNTSKEServer(ctx, log, copyIP(localAddr.Host.IP), localAddr.Host.Port, tlsConfig, provider)
-	server.StartSCIONNTSKEServer(ctx, log, copyIP(localAddr.Host.IP), localAddr.Host.Port, tlsConfig, provider, udp.UDPAddrFromSnet(localAddr))
+	server.StartNTSKEServerIP(ctx, log, copyIP(localAddr.Host.IP), localAddr.Host.Port, tlsConfig, provider)
+	server.StartNTSKEServerSCION(ctx, log, udp.UDPAddrFromSnet(localAddr), tlsConfig, provider)
 	server.StartIPServer(ctx, log, snet.CopyUDPAddr(localAddr.Host), provider)
 	server.StartSCIONServer(ctx, log, daemonAddr, snet.CopyUDPAddr(localAddr.Host), provider)
 
@@ -468,8 +468,8 @@ func runRelay(configFile string) {
 	tlsConfig := tlsConfig(cfg)
 	provider := ntske.NewProvider()
 
-	server.StartNTSKEServer(ctx, log, copyIP(localAddr.Host.IP), localAddr.Host.Port, tlsConfig, provider)
-	server.StartSCIONNTSKEServer(ctx, log, copyIP(localAddr.Host.IP), localAddr.Host.Port, tlsConfig, provider, udp.UDPAddrFromSnet(localAddr))
+	server.StartNTSKEServerIP(ctx, log, copyIP(localAddr.Host.IP), localAddr.Host.Port, tlsConfig, provider)
+	server.StartNTSKEServerSCION(ctx, log, udp.UDPAddrFromSnet(localAddr), tlsConfig, provider)
 	server.StartIPServer(ctx, log, snet.CopyUDPAddr(localAddr.Host), provider)
 	server.StartSCIONServer(ctx, log, daemonAddr, snet.CopyUDPAddr(localAddr.Host), provider)
 


### PR DESCRIPTION
Open questions:

- [ ] naming convention for NTSKE server functions (SCION/IP or QUIC/TCP)
- [ ] in timeservice remove QUIC examples
- [ ] default QUIC port