### PR TITLE
Simplify local port configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ sudo ~/scion-time/timeservice server -verbose -config testnet/test-server.toml
 In an additional session:
 
 ```
-~/scion-time/timeservice tool -verbose -local 0-0,0.0.0.0:0 -remote 0-0,127.0.0.1:10123
+~/scion-time/timeservice tool -verbose -local 0-0,0.0.0.0 -remote 0-0,127.0.0.1:123
 ```
 
 ## Querying an IP-based server with Network Time Security (NTS)
@@ -50,7 +50,7 @@ In an additional session:
 In an additional session:
 
 ```
-~/scion-time/timeservice tool -verbose -local 0-0,0.0.0.0:0 -remote 0-0,127.0.0.1:4460 -auth nts -ntske-insecure-skip-verify
+~/scion-time/timeservice tool -verbose -local 0-0,0.0.0.0 -remote 0-0,127.0.0.1:4460 -auth nts -ntske-insecure-skip-verify
 ```
 
 ## Installing prerequisites for a SCION test environment
@@ -129,14 +129,14 @@ rm -rf logs
 
 ## Running the servers
 
-In session no. 1, run server at `1-ff00:0:111,10.1.1.11:123`:
+In session no. 1, run server at `1-ff00:0:111,10.1.1.11:10123`:
 
 ```
 cd ~/scion-time
 sudo ip netns exec netns0 ./timeservice server -verbose -config testnet/gen-eh/ASff00_0_111/ts1-ff00_0_111-1.toml
 ```
 
-In session no. 2, run server at `1-ff00:0:112,10.1.1.12:123`:
+In session no. 2, run server at `1-ff00:0:112,10.1.1.12:10123`:
 
 ```
 cd ~/scion-time
@@ -145,58 +145,58 @@ sudo ip netns exec netns1 ./timeservice server -verbose -config testnet/gen-eh/A
 
 ## Querying SCION-based servers
 
-In an additional session, query server at `1-ff00:0:111,10.1.1.11:123` from `1-ff00:0:112,10.1.1.12`:
+In an additional session, query server at `1-ff00:0:111,10.1.1.11:10123` from `1-ff00:0:112,10.1.1.12`:
 
 ```
-sudo ip netns exec netns1 ~/scion-time/timeservice tool -verbose -daemon 10.1.1.12:30255 -local 1-ff00:0:112,10.1.1.12:0 -remote 1-ff00:0:111,10.1.1.11:123
+sudo ip netns exec netns1 ~/scion-time/timeservice tool -verbose -daemon 10.1.1.12:30255 -local 1-ff00:0:112,10.1.1.12 -remote 1-ff00:0:111,10.1.1.11:10123
 ```
 
-Or query server at `1-ff00:0:112,10.1.1.12:123` from `1-ff00:0:111,10.1.1.11`:
+Or query server at `1-ff00:0:112,10.1.1.12:10123` from `1-ff00:0:111,10.1.1.11`:
 
 ```
-sudo ip netns exec netns0 ~/scion-time/timeservice tool -verbose -daemon 10.1.1.11:30255 -local 1-ff00:0:111,10.1.1.11:0 -remote 1-ff00:0:112,10.1.1.12:123
+sudo ip netns exec netns0 ~/scion-time/timeservice tool -verbose -daemon 10.1.1.11:30255 -local 1-ff00:0:111,10.1.1.11 -remote 1-ff00:0:112,10.1.1.12:10123
 ```
 
 ### Querying a SCION-based server with SCION Packet Authenticator Option (SPAO)
 
 ```
-sudo ip netns exec netns1 ~/scion-time/timeservice tool -verbose -daemon 10.1.1.12:30255 -local 1-ff00:0:112,10.1.1.12:0 -remote 1-ff00:0:111,10.1.1.11:123 -auth spao
+sudo ip netns exec netns1 ~/scion-time/timeservice tool -verbose -daemon 10.1.1.12:30255 -local 1-ff00:0:112,10.1.1.12 -remote 1-ff00:0:111,10.1.1.11:10123 -auth spao
 ```
 
 ### Querying a SCION-based server with Network Time Security (NTS)
 
 ```
-sudo ip netns exec netns1 ~/scion-time/timeservice tool -verbose -daemon 10.1.1.12:30255 -local 1-ff00:0:112,10.1.1.12:0 -remote 1-ff00:0:111,10.1.1.11:4460 -auth nts -ntske-insecure-skip-verify
+sudo ip netns exec netns1 ~/scion-time/timeservice tool -verbose -daemon 10.1.1.12:30255 -local 1-ff00:0:112,10.1.1.12 -remote 1-ff00:0:111,10.1.1.11:14460 -auth nts -ntske-insecure-skip-verify
 ```
 
 ### Querying a SCION-based server with SPAO and NTS
 
 ```
-sudo ip netns exec netns1 ~/scion-time/timeservice tool -verbose -daemon 10.1.1.12:30255 -local 1-ff00:0:112,10.1.1.12:0 -remote 1-ff00:0:111,10.1.1.11:4460 -auth spao,nts -ntske-insecure-skip-verify
+sudo ip netns exec netns1 ~/scion-time/timeservice tool -verbose -daemon 10.1.1.12:30255 -local 1-ff00:0:112,10.1.1.12 -remote 1-ff00:0:111,10.1.1.11:14460 -auth spao,nts -ntske-insecure-skip-verify
 ```
 
 ### Querying a SCION-based server via IP
 
 ```
-sudo ip netns exec netns1 ~/scion-time/timeservice tool -verbose -local 0-0,10.1.1.12:0 -remote 0-0,10.1.1.11:4460
+sudo ip netns exec netns1 ~/scion-time/timeservice tool -verbose -local 0-0,10.1.1.12 -remote 0-0,10.1.1.11:123
 ```
 
 ### Querying a SCION-based server via IP with NTS
 
 ```
-sudo ip netns exec netns1 ~/scion-time/timeservice tool -verbose -local 0-0,10.1.1.12:0 -remote 0-0,10.1.1.11:4460 -auth nts -ntske-insecure-skip-verify
+sudo ip netns exec netns1 ~/scion-time/timeservice tool -verbose -local 0-0,10.1.1.12 -remote 0-0,10.1.1.11:4460 -auth nts -ntske-insecure-skip-verify
 ```
 
 ## Synchronizing with a SCION-based server
 
-In session no. 1, run server at `1-ff00:0:111,10.1.1.11:123`:
+In session no. 1, run server at `1-ff00:0:111,10.1.1.11:10123`:
 
 ```
 cd ~/scion-time
 sudo ip netns exec netns0 ./timeservice server -verbose -config testnet/gen-eh/ASff00_0_111/ts1-ff00_0_111-1.toml
 ```
 
-And in session no. 2, synchronize node `1-ff00:0:112,10.1.1.12` with server at `1-ff00:0:111,10.1.1.11:123`:
+And in session no. 2, synchronize node `1-ff00:0:112,10.1.1.12` with server at `1-ff00:0:111,10.1.1.11:10123`:
 
 ```
 cd ~/scion-time

--- a/core/server/ntske.go
+++ b/core/server/ntske.go
@@ -9,8 +9,6 @@ import (
 	"example.com/scion-time/net/ntske"
 )
 
-const defaultNTSKEPort = 4460
-
 var errNoCookie = errors.New("failed to add at least one cookie")
 
 func newNTSKEMsg(log *zap.Logger, localIP net.IP, localPort int, data *ntske.Data, provider *ntske.Provider) (ntske.ExchangeMsg, error) {

--- a/core/server/ntske_ip.go
+++ b/core/server/ntske_ip.go
@@ -87,10 +87,10 @@ func runNTSKEServerTLS(log *zap.Logger, listener net.Listener, localPort int, pr
 }
 
 func StartNTSKEServerIP(ctx context.Context, log *zap.Logger, localIP net.IP, localPort int, config *tls.Config, provider *ntske.Provider) {
-	ntskeAddr := net.JoinHostPort(localIP.String(), strconv.Itoa(defaultNTSKEPort))
+	ntskeAddr := net.JoinHostPort(localIP.String(), strconv.Itoa(ntske.ServerPortIP))
 	log.Info("server listening via IP",
 		zap.Stringer("ip", localIP),
-		zap.Int("port", defaultNTSKEPort),
+		zap.Int("port", ntske.ServerPortIP),
 	)
 
 	listener, err := tls.Listen("tcp", ntskeAddr, config)

--- a/core/server/ntske_scion.go
+++ b/core/server/ntske_scion.go
@@ -106,11 +106,11 @@ func runNTSKEServerQUIC(ctx context.Context, log *zap.Logger, listener quic.List
 func StartNTSKEServerSCION(ctx context.Context, log *zap.Logger, localAddr udp.UDPAddr, config *tls.Config, provider *ntske.Provider) {
 	log.Info("server listening via SCION",
 		zap.Stringer("ip", localAddr.Host.IP),
-		zap.Int("port", defaultNTSKEPort),
+		zap.Int("port", ntske.ServerPortSCION),
 	)
 
 	localPort := localAddr.Host.Port
-	localAddr.Host.Port = defaultNTSKEPort
+	localAddr.Host.Port = ntske.ServerPortSCION
 
 	listener, err := scion.ListenQUIC(ctx, localAddr, config, nil /* quicCfg */)
 	if err != nil {

--- a/net/ntp/ntp.go
+++ b/net/ntp/ntp.go
@@ -9,7 +9,8 @@ import (
 const (
 	nanosecondsPerSecond int64 = 1e9
 
-	ServerPort = 123
+	ServerPortIP    = 123
+	ServerPortSCION = 10123
 
 	PacketLen = 48
 

--- a/net/ntp/validation.go
+++ b/net/ntp/validation.go
@@ -51,8 +51,5 @@ func ValidateRequest(req *Packet, srcPort uint16) error {
 	if vn == 1 && mode != ModeReserved0 || vn != 1 && mode != ModeClient {
 		return errUnexpectedRequest
 	}
-	if vn == 1 && srcPort == ServerPort {
-		return errUnexpectedRequest
-	}
 	return nil
 }

--- a/net/ntske/ntske.go
+++ b/net/ntske/ntske.go
@@ -56,8 +56,9 @@ const (
 
 const (
 	AES_SIV_CMAC_256   = 0x0f
-	DEFAULT_NTSKE_PORT = 4460
-	DEFAULT_NTP_PORT   = 123
+	
+	ServerPortIP    = 4460
+	ServerPortSCION = 14460
 )
 
 const (

--- a/net/ntske/ntske.go
+++ b/net/ntske/ntske.go
@@ -55,8 +55,8 @@ const (
 )
 
 const (
-	AES_SIV_CMAC_256   = 0x0f
-	
+	AES_SIV_CMAC_256 = 0x0f
+
 	ServerPortIP    = 4460
 	ServerPortSCION = 14460
 )

--- a/net/ntske/ntske_ip.go
+++ b/net/ntske/ntske_ip.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+
+	"example.com/scion-time/net/ntp"
 )
 
 func AcceptTLSConn(l net.Listener) (*tls.Conn, error) {
@@ -33,14 +35,13 @@ func dialTLS(hostport string, config *tls.Config) (*tls.Conn, Data, error) {
 		if !strings.Contains(err.Error(), "missing port in address") {
 			return nil, Data{}, err
 		}
-		hostport = net.JoinHostPort(hostport, strconv.Itoa(DEFAULT_NTSKE_PORT))
+		hostport = net.JoinHostPort(hostport, strconv.Itoa(ServerPortIP))
 	}
 
 	conn, err := tls.DialWithDialer(&net.Dialer{
 		Timeout: time.Second * 5,
 	}, "tcp", hostport, config)
 	if err != nil {
-		_ = conn.Close()
 		return nil, Data{}, err
 	}
 
@@ -50,7 +51,7 @@ func dialTLS(hostport string, config *tls.Config) (*tls.Conn, Data, error) {
 		_ = conn.Close()
 		return nil, Data{}, err
 	}
-	data.Port = DEFAULT_NTP_PORT
+	data.Port = ntp.ServerPortIP
 
 	state := conn.ConnectionState()
 	if state.NegotiatedProtocol != alpn {

--- a/net/ntske/ntske_scion.go
+++ b/net/ntske/ntske_scion.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/scionproto/scion/pkg/daemon"
 
+	"example.com/scion-time/net/ntp"
 	"example.com/scion-time/net/scion"
 	"example.com/scion-time/net/udp"
 )
@@ -49,7 +50,7 @@ func dialQUIC(log *zap.Logger, localAddr, remoteAddr udp.UDPAddr, daemonAddr str
 		_ = conn.Close()
 		return nil, Data{}, err
 	}
-	data.Port = DEFAULT_NTP_PORT
+	data.Port = ntp.ServerPortSCION
 
 	return conn, data, nil
 }

--- a/testnet/benchmark/config/ip_nonauth_benchmark.toml
+++ b/testnet/benchmark/config/ip_nonauth_benchmark.toml
@@ -1,4 +1,4 @@
-local_address = "0-0,0.0.0.0:0"
+local_address = "0-0,0.0.0.0"
 remote_address = "0-0,10.1.1.11:4460"
 
 auth_modes = []

--- a/testnet/benchmark/config/ip_nts_benchmark.toml
+++ b/testnet/benchmark/config/ip_nts_benchmark.toml
@@ -1,4 +1,4 @@
-local_address = "0-0,0.0.0.0:0"
+local_address = "0-0,0.0.0.0"
 remote_address = "0-0,10.1.1.11:4460"
 
 auth_modes = ["nts"]

--- a/testnet/benchmark/config/scion_nonauth_benchmark.toml
+++ b/testnet/benchmark/config/scion_nonauth_benchmark.toml
@@ -1,4 +1,4 @@
-local_address = "1-ff00:0:111,0.0.0.0:0"
-remote_address = "1-ff00:0:111,10.1.1.11:123"
+local_address = "1-ff00:0:111,0.0.0.0"
+remote_address = "1-ff00:0:111,10.1.1.11:10123"
 
 auth_modes = []

--- a/testnet/benchmark/config/scion_nts_benchmark.toml
+++ b/testnet/benchmark/config/scion_nts_benchmark.toml
@@ -1,5 +1,5 @@
-local_address = "1-ff00:0:111,0.0.0.0:0"
-remote_address = "1-ff00:0:111,10.1.1.11:4460"
+local_address = "1-ff00:0:111,0.0.0.0"
+remote_address = "1-ff00:0:111,10.1.1.11:14460"
 
 auth_modes = ["nts"]
 ntske_insecure_skip_verify = true

--- a/testnet/benchmark/config/scion_spao_benchmark.toml
+++ b/testnet/benchmark/config/scion_spao_benchmark.toml
@@ -1,4 +1,4 @@
-local_address = "1-ff00:0:111,0.0.0.0:0"
-remote_address = "1-ff00:0:111,10.1.1.11:123"
+local_address = "1-ff00:0:111,0.0.0.0"
+remote_address = "1-ff00:0:111,10.1.1.11:10123"
 
 auth_modes = ["spao"]

--- a/testnet/benchmark/config/scion_spao_nts_benchmark.toml
+++ b/testnet/benchmark/config/scion_spao_nts_benchmark.toml
@@ -1,5 +1,5 @@
-local_address = "1-ff00:0:111,0.0.0.0:0"
-remote_address = "1-ff00:0:111,10.1.1.11:4460"
+local_address = "1-ff00:0:111,0.0.0.0"
+remote_address = "1-ff00:0:111,10.1.1.11:14460"
 
 auth_modes = ["nts", "spao"]
 ntske_insecure_skip_verify = true

--- a/testnet/gen-eh/ASff00_0_111/test-client-nts.toml
+++ b/testnet/gen-eh/ASff00_0_111/test-client-nts.toml
@@ -1,4 +1,4 @@
-local_address = "0-0,10.1.1.11:0"
+local_address = "0-0,10.1.1.11"
 
 ntp_reference_clocks = ["0-0,10.1.1.12:4460"]
 

--- a/testnet/gen-eh/ASff00_0_111/test-client.toml
+++ b/testnet/gen-eh/ASff00_0_111/test-client.toml
@@ -1,4 +1,4 @@
-local_address = "1-ff00:0:111,10.1.1.11:0"
+local_address = "1-ff00:0:111,10.1.1.11"
 daemon_address = "10.1.1.11:30255"
 
-ntp_reference_clocks = ["1-ff00:0:112,10.1.1.12:123"]
+ntp_reference_clocks = ["1-ff00:0:112,10.1.1.12:10123"]

--- a/testnet/gen-eh/ASff00_0_111/ts1-ff00_0_111-1.toml
+++ b/testnet/gen-eh/ASff00_0_111/ts1-ff00_0_111-1.toml
@@ -1,9 +1,9 @@
-local_address = "1-ff00:0:111,10.1.1.11:123"
+local_address = "1-ff00:0:111,10.1.1.11"
 daemon_address = "10.1.1.11:30255"
 
 mbg_reference_clocks = ["/dev/mbgclock0"]
 ntp_reference_clocks = ["0-0,time.apple.com:123", "0-0,time.facebook.com:123", "0-0,time.google.com:123", "0-0,time.windows.com:123"]
-scion_peers = ["1-ff00:0:112,10.1.1.12:123"]
+scion_peers = ["1-ff00:0:112,10.1.1.12:10123"]
 auth_modes = ["spao"]
 
 ntske_cert_file = "testnet/gen/tls.crt"

--- a/testnet/gen-eh/ASff00_0_112/test-client-nts.toml
+++ b/testnet/gen-eh/ASff00_0_112/test-client-nts.toml
@@ -1,4 +1,4 @@
-local_address = "0-0,10.1.1.12:0"
+local_address = "0-0,10.1.1.12"
 
 ntp_reference_clocks = ["0-0,10.1.1.11:4460"]
 

--- a/testnet/gen-eh/ASff00_0_112/test-client.toml
+++ b/testnet/gen-eh/ASff00_0_112/test-client.toml
@@ -1,4 +1,4 @@
-local_address = "1-ff00:0:112,10.1.1.12:0"
+local_address = "1-ff00:0:112,10.1.1.12"
 daemon_address = "10.1.1.12:30255"
 
-ntp_reference_clocks = ["1-ff00:0:111,10.1.1.11:123"]
+ntp_reference_clocks = ["1-ff00:0:111,10.1.1.11:10123"]

--- a/testnet/gen-eh/ASff00_0_112/ts1-ff00_0_112-1.toml
+++ b/testnet/gen-eh/ASff00_0_112/ts1-ff00_0_112-1.toml
@@ -1,9 +1,9 @@
-local_address = "1-ff00:0:112,10.1.1.12:123"
+local_address = "1-ff00:0:112,10.1.1.12"
 daemon_address = "10.1.1.12:30255"
 
 mbg_reference_clocks = ["/dev/mbgclock0"]
 ntp_reference_clocks = ["0-0,time.apple.com:123", "0-0,time.facebook.com:123", "0-0,time.google.com:123", "0-0,time.windows.com:123"]
-scion_peers = ["1-ff00:0:111,10.1.1.11:123"]
+scion_peers = ["1-ff00:0:111,10.1.1.11:10123"]
 auth_modes = ["spao"]
 
 ntske_cert_file = "testnet/gen/tls.crt"

--- a/testnet/test-client.toml
+++ b/testnet/test-client.toml
@@ -1,2 +1,2 @@
-local_address = "0-0,0.0.0.0:0"
+local_address = "0-0,0.0.0.0"
 ntp_reference_clocks = ["0-0,time.facebook.com:123"]

--- a/testnet/test-server.toml
+++ b/testnet/test-server.toml
@@ -1,4 +1,4 @@
-local_address = "0-0,0.0.0.0:10123"
+local_address = "0-0,0.0.0.0"
 ntp_reference_clocks = ["0-0,time.facebook.com:123"]
 
 ntske_cert_file = "./testnet/gen/tls.crt"


### PR DESCRIPTION
Server side ports are now assigned as follows:
  - NTP/IP port: 123
  - NTSKE/IP port: 4460
  - NTP/SCION port: 10123
  - NTSKE/SCION port: 14460

While this set of changes removes flexibility in the configuration space it also makes the system easier to describe and it hopefully helps to avoid a number of complicated edge cases and error conditions.