### PR TITLE
Add variant in Theil-Sen estimator to drop samples when needed

### DIFF
--- a/core/sync/theil_sen.go
+++ b/core/sync/theil_sen.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"math"
 	"sort"
 	"time"
 
@@ -18,6 +19,7 @@ type theilSen struct {
 
 // If the buffer size is too large, the system is likely to oscillate heavily.
 const maxSamples = 4
+const maxAllowedBias = 1000.0
 
 const baseFreqGainFactor = 0.005
 
@@ -107,6 +109,28 @@ func (ts *theilSen) AddSample(offset time.Duration) {
 	ts.samples = append(ts.samples, sample{x: now, y: now.Add(offset)})
 }
 
+func runIterations(pts []point) (float64, float64, int) {
+	n := len(pts)
+
+	for i := 0; i < n; i++ {
+		slope := slope(pts[i:])
+		intercept := intercept(slope, pts[i:])
+
+		bias := 0.0
+		for j := i; j < n; j++ {
+			bias += math.Abs(prediction(slope, intercept, float64(pts[j].x)) - float64(pts[j].y))
+		}
+		bias /= float64(n - i)
+
+		if math.Abs(bias) < maxAllowedBias {
+			return slope, intercept, i
+		}
+	}
+
+	defaultSlope := slope(pts)
+	return defaultSlope, intercept(defaultSlope, pts), 0
+}
+
 func (ts *theilSen) Offset() (time.Duration, bool) {
 	if len(ts.samples) == 0 {
 		return time.Duration(0), false
@@ -114,13 +138,16 @@ func (ts *theilSen) Offset() (time.Duration, bool) {
 
 	now := ts.clk.Now()
 	regressionPts := regressionPts(ts.samples)
-	slope := slope(regressionPts)
-	intercept := intercept(slope, regressionPts)
+	slope, intercept, bestStart := runIterations(regressionPts)
+
 	predictedTime := prediction(slope, intercept, float64(now.Sub(ts.samples[0].x).Nanoseconds()))
 	predictedOffset := predictedTime - float64(now.Sub(ts.samples[0].x).Nanoseconds())
 
+	ts.samples = ts.samples[bestStart:]
+
 	ts.log.Debug("Theil-Sen estimate",
 		zap.Int("# of samples", len(ts.samples)),
+		zap.Int("best start", bestStart),
 		zap.Float64("slope", slope),
 		zap.Float64("intercept", intercept),
 		zap.Float64("predicted offset (ns)", predictedOffset),

--- a/core/sync/theil_sen.go
+++ b/core/sync/theil_sen.go
@@ -20,6 +20,7 @@ type theilSen struct {
 // If the buffer size is too large, the system is likely to oscillate heavily.
 const maxSamples = 4
 const maxAllowedBias = 1000.0
+const dropEnabled = true
 
 const baseFreqGainFactor = 0.005
 
@@ -110,6 +111,11 @@ func (ts *theilSen) AddSample(offset time.Duration) {
 }
 
 func runIterations(pts []point) (float64, float64, int) {
+	if !dropEnabled {
+		slope := slope(pts)
+		return slope, intercept(slope, pts), 0
+	}
+
 	n := len(pts)
 
 	for i := 0; i < n; i++ {

--- a/core/sync/theil_sen.go
+++ b/core/sync/theil_sen.go
@@ -19,7 +19,7 @@ type theilSen struct {
 
 // If the buffer size is too large, the system is likely to oscillate heavily.
 const maxSamples = 4
-const maxAllowedBias = 1000.0
+const maxAllowedErr = 1000.0
 const dropEnabled = true
 
 const baseFreqGainFactor = 0.005
@@ -122,13 +122,13 @@ func runIterations(pts []point) (float64, float64, int) {
 		slope := slope(pts[i:])
 		intercept := intercept(slope, pts[i:])
 
-		bias := 0.0
+		err := 0.0
 		for j := i; j < n; j++ {
-			bias += math.Abs(prediction(slope, intercept, float64(pts[j].x)) - float64(pts[j].y))
+			err += math.Abs(prediction(slope, intercept, float64(pts[j].x)) - float64(pts[j].y))
 		}
-		bias /= float64(n - i)
+		err /= float64(n - i)
 
-		if math.Abs(bias) < maxAllowedBias {
+		if math.Abs(err) < maxAllowedErr {
 			return slope, intercept, i
 		}
 	}


### PR DESCRIPTION
This adds a variant of the Theil-Sen estimator that can be enabled/disabled through the `dropEnabled` variable.

It calculates an error term for how good the prediction of Theil-Sen is. If the error term is too large, it drops the oldest samples until the error term becomes small enough. This helps prevent oscillations, because the prediction will become more responsive towards a change once the error term grows over the threshold.